### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Or grab the most recent (development) version of the package with `devtools`:
 
 ```r
 library(devtools)
-install_github('rapportools', 'rapporter')
+install_github('rapporter/rapportools')
 ```
 
 The build status of that latter: [![Build Status](https://travis-ci.org/Rapporter/rapportools.png?branch=master)](https://travis-ci.org/Rapporter/rapportools)


### PR DESCRIPTION
changed the install_github parameters to match new specifications (otherwise we get a warning: "username parameter is deprecated").